### PR TITLE
:method arguments in 'destructuring-bind' macro was bind to nil.

### DIFF
--- a/src/myway.lisp
+++ b/src/myway.lisp
@@ -61,5 +61,5 @@
 (defun to-app (mapper)
   (lambda (env)
     (let ((*env* env))
-      (destructuring-bind (&key method path-info &allow-other-keys) env
-        (dispatch mapper path-info :method method)))))
+      (destructuring-bind (&key request-method path-info &allow-other-keys) env
+        (dispatch mapper path-info :method request-method)))))

--- a/t/myway.lisp
+++ b/t/myway.lisp
@@ -40,7 +40,7 @@
 (is (dispatch *mapper* "/new" :method :GET) "new")
 
 (is (funcall (to-app *mapper*)
-             '(:method :GET :path-info "/"))
+             '(:request-method :GET :path-info "/"))
     "Hello, World!")
 
 (connect *mapper* "/id/:n"


### PR DESCRIPTION
When run the sample code, the following error has occurred.

```
The value NIL is not of the expected type KEYWORD.
```

code and request that I have run is the following.

``` .lisp
(use-package :clack)
(use-package :myway)

(defvar *mapper* (make-mapper))

(connect *mapper* "/" '(200 (:content-type "text/plain") ("Hello, Clack!")))

(clack:clackup (to-app *mapper*))
```

```
$ curl http://localhost:5000/
```

So I think, argument "ENV" does not seem to have ":METHOD" parameter.

Finally, this pull-request fixed a name of keyword argument, However, I'm not sure if this is correct.
