### PR TITLE
add "find-route-by-name"

### DIFF
--- a/src/mapper.lisp
+++ b/src/mapper.lisp
@@ -4,6 +4,7 @@
   (:import-from :myway.route
                 :route-rule
                 :route-handler
+                :route-name
                 :equal-route
                 :match-route)
   (:import-from :myway.rule
@@ -18,6 +19,7 @@
            :make-mapper
            :mapper-routes
            :member-route
+           :member-route-by-name
            :add-route
            :next-route
            :dispatch))
@@ -36,6 +38,12 @@
   (member route
           (mapper-routes mapper)
           :test #'equal-route))
+
+(defun member-route-by-name (mapper name)
+  (member name
+          (mapper-routes mapper)
+          :test #'eq
+          :key #'route-name))
 
 (defun add-route (mapper route)
   (let ((routes (member-route mapper route)))

--- a/src/myway.lisp
+++ b/src/myway.lisp
@@ -7,6 +7,7 @@
                 :mapper-routes
                 :make-mapper
                 :member-route
+                :member-route-by-name
                 :add-route
                 :next-route
                 :dispatch)
@@ -32,6 +33,7 @@
            :mapper-routes
            :add-route
            :find-route
+           :find-route-by-name
 
            :route
            :route-name
@@ -57,6 +59,10 @@
                  (apply #'make-instance route-class
                         :url url
                         (delete-from-plist args :route-class)))))
+
+(defun find-route-by-name (mapper name)
+  (car
+   (member-route-by-name mapper name)))
 
 (defparameter *env* nil)
 

--- a/t/myway.lisp
+++ b/t/myway.lisp
@@ -21,6 +21,14 @@
 (is (find-route *mapper* "/" :method :POST) nil)
 (is (dispatch *mapper* "/" :method :GET) "Hello, World!")
 
+(connect *mapper* "/"
+         (lambda (params)
+           (declare (ignore params))
+           "Hello, World!")
+         :name :test)
+(ok (find-route-by-name *mapper* :test))
+(is (find-route-by-name *mapper* :test) (find-route *mapper* "/" :name :test))
+
 (connect *mapper* "/post"
          (lambda (params)
            (declare (ignore params))


### PR DESCRIPTION
This adds a function to find a route by its name field only, which is extremely useful for generating urls at runtime.